### PR TITLE
🔀 Feature/renaming cli command

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - feature/*
 jobs:
   actions:
     runs-on: ubuntu-latest
@@ -32,20 +33,25 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
     - name: Sube latest a Docker Hub
+      if: github.ref_name == 'develop'
       run: docker push islasgeci/population_trend:latest
     - name: Sube sha a Docker Hub
+      if: github.ref_name == 'develop'
       run: docker push islasgeci/population_trend:${GITHUB_SHA:0:4}
     - name: Set up Python 3.9
+      if: github.ref_name == 'develop'
       uses: actions/setup-python@master
       with:
         python-version: 3.9
     - name: Install pypa/build
+      if: github.ref_name == 'develop'
       run: >-
         python -m
         pip install
         build
         --user
     - name: Build a binary wheel and a source tarball
+      if: github.ref_name == 'develop'
       run: >-
         python -m
         build
@@ -54,6 +60,7 @@ jobs:
         --outdir dist/
         .
     - name: Publish distribution 📦 to PyPI
+      if: github.ref_name == 'develop'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- New CLI command `render-population-trend` with identical behavior to `plot-population-trend`.
 
 ### Fixed
 
 ### Changed
 
 ### Deprecated
-- CLI command `plot-population-trend` is deprecated in favor of `render-population-trend`. The old command will remain functional and will be removed in v6.0.0. Users should update their scripts and automation to use `render-population-trend` instead.
 
 ### Removed
 
+## [5.11.0] - 2026-05-11
+### Added
+- New CLI command `render-population-trend` with identical behavior to `plot-population-trend`.
+### Deprecated
+- CLI command `plot-population-trend` is deprecated in favor of `render-population-trend`. The old command will remain functional and will be removed in v6.0.0. Users should update their scripts and automation to use `render-population-trend` instead.
 ## [5.10.2] - 2026-02-05
 ### Fixed
 - CLI command `plot-population-trend-from-cpue` can plot data with missing seasons.
@@ -135,6 +138,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 
-[unreleased]: https://github.com/IslasGECI/population_trend/compare/v5.5.0...HEAD
+[unreleased]: https://github.com/IslasGECI/population_trend/compare/v5.11.0...HEAD
+[5.11.0]: https://github.com/IslasGECI/population_trend/compare/v5.10.2...v5.11.0
+[5.10.2]: https://github.com/IslasGECI/population_trend/compare/v5.10.1...v5.10.2
+[5.10.1]: https://github.com/IslasGECI/population_trend/compare/v5.10.0...v5.10.1
+[5.10.0]: https://github.com/IslasGECI/population_trend/compare/v5.9.1...v5.10.0
+[5.9.1]: https://github.com/IslasGECI/population_trend/compare/v5.9.0...v5.9.1
+[5.9.0]: https://github.com/IslasGECI/population_trend/compare/v5.8.0...v5.9.0
+[5.8.0]: https://github.com/IslasGECI/population_trend/compare/v5.7.2...v5.8.0
+[5.7.2]: https://github.com/IslasGECI/population_trend/compare/v5.7.1...v5.7.2
+[5.7.1]: https://github.com/IslasGECI/population_trend/compare/v5.7.0...v5.7.1
+[5.7.0]: https://github.com/IslasGECI/population_trend/compare/v5.6.1...v5.7.0
+[5.6.1]: https://github.com/IslasGECI/population_trend/compare/v5.6.0...v5.6.1
+[5.6.0]: https://github.com/IslasGECI/population_trend/compare/v5.5.0...v5.6.0
 [5.5.0]: https://github.com/IslasGECI/population_trend/compare/v5.4.0...v5.5.0
 [0.0.1]: https://github.com/IslasGECI/population_trend/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- New CLI command `render-population-trend` with identical behavior to `plot-population-trend`.
 
 ### Fixed
 
 ### Changed
+
+### Deprecated
+- CLI command `plot-population-trend` is deprecated in favor of `render-population-trend`. The old command will remain functional and will be removed in v6.0.0. Users should update their scripts and automation to use `render-population-trend` instead.
 
 ### Removed
 

--- a/population_trend/__init__.py
+++ b/population_trend/__init__.py
@@ -1,6 +1,6 @@
 """A population growth model package"""
 
-__version__ = "5.10.2"
+__version__ = "5.11.0"
 from .calculate_growth_rates import *  # noqa
 from .cli import *  # noqa
 from .filter_data import *  # noqa

--- a/population_trend/cli.py
+++ b/population_trend/cli.py
@@ -113,7 +113,7 @@ def plot_population_trend(
 ):
     """(DEPRECATED) Plot population trend. Use 'render-population-trend' instead."""
     typer.secho(
-        "WARNING: 'plot-population-trend' is deprecated and will be removed in v2.0.0. "
+        "WARNING: 'plot-population-trend' is deprecated and will be removed in v6.0.0. "
         "Use 'render-population-trend' instead.",
         fg=typer.colors.YELLOW,
         err=True,
@@ -121,7 +121,7 @@ def plot_population_trend(
 
     warnings.warn(
         "'plot-population-trend' is deprecated, use 'render-population-trend' instead. "
-        "This command will be removed in v2.0.0.",
+        "This command will be removed in v6.0.0.",
         DeprecationWarning,
         stacklevel=2,
     )

--- a/population_trend/cli.py
+++ b/population_trend/cli.py
@@ -102,7 +102,10 @@ def render_population_trend(
     )
 
 
-@app.command(help="(DEPRECATED) Plot population trend. Use 'render-population-trend' instead.")
+@app.command(
+    help="(DEPRECATED) Plot population trend. Use 'render-population-trend' instead.",
+    deprecated=True,
+)
 def plot_population_trend(
     data_path: Annotated[str, typer.Option()],
     intervals_path: Annotated[str, typer.Option()],

--- a/population_trend/cli.py
+++ b/population_trend/cli.py
@@ -23,6 +23,7 @@ from typing_extensions import Annotated
 import typer
 import json
 import matplotlib.pyplot as plt
+import warnings
 
 app = typer.Typer(help="Write filtered burrows data by species and island")
 
@@ -62,15 +63,15 @@ def write_burrows_by_species_and_island(
     filtered.to_csv(output_path, index=False)
 
 
-@app.command(help="Plot population trend")
-def plot_population_trend(
-    data_path: Annotated[str, typer.Option()],
-    intervals_path: Annotated[str, typer.Option()],
-    island: Annotated[str, typer.Option()] = "Guadalupe",
-    variable_of_interest: Annotated[str, typer.Option()] = "Maxima_cantidad_nidos",
-    tick_mode: Annotated[str, typer.Option()] = "full",
-    output_path: Annotated[str, typer.Option()] = "",
+def _render_population_trend(
+    data_path: str,
+    intervals_path: str,
+    island: str = "Guadalupe",
+    variable_of_interest: str = "Maxima_cantidad_nidos",
+    tick_mode: str = "full",
+    output_path: str = "",
 ):
+    """Shared implementation for rendering population trend plots."""
     fit_data = pd.read_csv(data_path)
     intervals_json = read_json(intervals_path)
     lambda_latex = intervals_json["lambda_latex_interval"]
@@ -85,6 +86,49 @@ def plot_population_trend(
     legend_mpl_object = Graficador.set_legend_location(island)
     Graficador.plot_growth_rate_interval(legend_mpl_object, lambda_latex)
     Graficador.savefig(island, output_path)
+
+
+@app.command(name="render-population-trend", help="Plot population trend")
+def render_population_trend(
+    data_path: Annotated[str, typer.Option()],
+    intervals_path: Annotated[str, typer.Option()],
+    island: Annotated[str, typer.Option()] = "Guadalupe",
+    variable_of_interest: Annotated[str, typer.Option()] = "Maxima_cantidad_nidos",
+    tick_mode: Annotated[str, typer.Option()] = "full",
+    output_path: Annotated[str, typer.Option()] = "",
+):
+    _render_population_trend(
+        data_path, intervals_path, island, variable_of_interest, tick_mode, output_path
+    )
+
+
+@app.command(help="(DEPRECATED) Plot population trend. Use 'render-population-trend' instead.")
+def plot_population_trend(
+    data_path: Annotated[str, typer.Option()],
+    intervals_path: Annotated[str, typer.Option()],
+    island: Annotated[str, typer.Option()] = "Guadalupe",
+    variable_of_interest: Annotated[str, typer.Option()] = "Maxima_cantidad_nidos",
+    tick_mode: Annotated[str, typer.Option()] = "full",
+    output_path: Annotated[str, typer.Option()] = "",
+):
+    """(DEPRECATED) Plot population trend. Use 'render-population-trend' instead."""
+    typer.secho(
+        "WARNING: 'plot-population-trend' is deprecated and will be removed in v2.0.0. "
+        "Use 'render-population-trend' instead.",
+        fg=typer.colors.YELLOW,
+        err=True,
+    )
+
+    warnings.warn(
+        "'plot-population-trend' is deprecated, use 'render-population-trend' instead. "
+        "This command will be removed in v2.0.0.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    _render_population_trend(
+        data_path, intervals_path, island, variable_of_interest, tick_mode, output_path
+    )
 
 
 @app.command(help="Plot population trend from CPUE")

--- a/population_trend/population_growth_model.py
+++ b/population_trend/population_growth_model.py
@@ -147,8 +147,9 @@ class Plotter_Population_Trend_Model:
         )
 
     def set_labels(self):
-        plt.ylabel("Number of breeding pairs", size=20)
-        plt.xlabel("Seasons", size=20)
+        labels = {"english": {"ylabel": "Number of breeding pairs", "xlabel": "Seasons"}}
+        plt.ylabel(labels["english"]["ylabel"], size=20)
+        plt.xlabel(labels["english"]["xlabel"], size=20)
 
     def set_ticks(self):
         self.get_tick_step()

--- a/tests/test_Population_trend.py
+++ b/tests/test_Population_trend.py
@@ -52,7 +52,6 @@ pop_model = Population_Trend_Model(
     {"intervals": [], "bootstrap_intermediate_distribution": []},
     "Maxima_cantidad_nidos",
 )
-Plotter = Plotter_Population_Trend_Model(cormorant_data_for_plotter, pop_model, tick_mode="full")
 
 
 more_cormorant_data = pd.DataFrame(
@@ -62,6 +61,10 @@ Sparse_Plotter = Plotter_Population_Trend_Model(more_cormorant_data, pop_model, 
 
 
 class Tests_Plotter_Population_Trend_Model:
+    Plotter = Plotter_Population_Trend_Model(
+        cormorant_data_for_plotter, pop_model, tick_mode="full"
+    )
+
     def tests_init_(self):
         fig, ax = geci_plot()
         assert type(fig) == type(Plotter.fig)  # noqa

--- a/tests/test_Population_trend.py
+++ b/tests/test_Population_trend.py
@@ -60,10 +60,10 @@ more_cormorant_data = pd.DataFrame(
 Sparse_Plotter = Plotter_Population_Trend_Model(more_cormorant_data, pop_model, tick_mode="sparse")
 
 
+Plotter = Plotter_Population_Trend_Model(cormorant_data_for_plotter, pop_model, tick_mode="full")
+
+
 class Tests_Plotter_Population_Trend_Model:
-    Plotter = Plotter_Population_Trend_Model(
-        cormorant_data_for_plotter, pop_model, tick_mode="full"
-    )
 
     def tests_init_(self):
         fig, ax = geci_plot()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import warnings
 import pandas as pd
 from typer.testing import CliRunner
 from population_trend import (
@@ -14,7 +15,7 @@ species = "Laysan Albatross"
 island = "Guadalupe"
 output_path = "tests/data/laal_guadalupe.csv"
 intervals_path = "tests/data/gumu_guadalupe_boostrap_intervals.json"
-output_figure = "tests/data/figure.png"
+data_path_for_trend = "tests/data/gumu_guadalupe_data.csv"
 
 
 def test_app_plot_growth_rate():
@@ -52,6 +53,13 @@ def test_app_plot_population_trend():
     assert "XX" not in result.stdout
     assert "[default: Guadalupe]" in result.stdout
     assert "[default: Maxima_cantidad_nidos]" in result.stdout
+    assert result.exit_code == 0
+    assert (
+        "DEPRECATED" in result.stdout
+    ), f"Expected 'DEPRECATED' in help text. Got: {result.stdout}"
+    assert (
+        "render-population-trend" in result.stdout
+    ), f"Expected new command name in help text. Got: {result.stdout}"
 
     data_path = "tests/data/gumu_guadalupe_data.csv"
     output_figure = "tests/data/plot_trend.png"
@@ -220,3 +228,33 @@ def test_write_burrows_by_species_and_island():
     obtained_columns = len(obtained_csv.columns)
     expected_columns = 12
     assert obtained_columns == expected_columns
+
+
+def test_render_population_trend_new_command_works():
+    output_figure_render = "tests/data/render_trend.png"
+    gtt.if_exist_remove(output_figure_render)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = runner.invoke(
+            app,
+            [
+                "render-population-trend",
+                "--data-path",
+                data_path_for_trend,
+                "--intervals-path",
+                intervals_path,
+                "--island",
+                "Guadalupe",
+                "--variable-of-interest",
+                "Maxima_cantidad_nidos",
+                "--tick-mode",
+                "sparse",
+                "--output-path",
+                output_figure_render,
+            ],
+        )
+
+    assert result.exit_code == 0
+    gtt.assert_exist(output_figure_render)
+    gtt.if_exist_remove(output_figure_render)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,3 @@
-import warnings
 import pandas as pd
 from typer.testing import CliRunner
 from population_trend import (
@@ -234,26 +233,24 @@ def test_render_population_trend_new_command_works():
     output_figure_render = "tests/data/render_trend.png"
     gtt.if_exist_remove(output_figure_render)
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        result = runner.invoke(
-            app,
-            [
-                "render-population-trend",
-                "--data-path",
-                data_path_for_trend,
-                "--intervals-path",
-                intervals_path,
-                "--island",
-                "Guadalupe",
-                "--variable-of-interest",
-                "Maxima_cantidad_nidos",
-                "--tick-mode",
-                "sparse",
-                "--output-path",
-                output_figure_render,
-            ],
-        )
+    result = runner.invoke(
+        app,
+        [
+            "render-population-trend",
+            "--data-path",
+            data_path_for_trend,
+            "--intervals-path",
+            intervals_path,
+            "--island",
+            "Guadalupe",
+            "--variable-of-interest",
+            "Maxima_cantidad_nidos",
+            "--tick-mode",
+            "sparse",
+            "--output-path",
+            output_figure_render,
+        ],
+    )
 
     assert result.exit_code == 0
     gtt.assert_exist(output_figure_render)


### PR DESCRIPTION
## Summary                                                                                                                                            
                                                                                                                                                      
- **Rename** the CLI command `plot-population-trend` to `render-population-trend`, marking the old name as deprecated.                                
- **Guard** all deploy/publish steps (Docker push, PyPI) so they only execute on the `develop` branch, preventing accidental releases from `feature/*`
 branches.                                                                                                                                            
- **Extract** shared plotting logic into a private `_render_population_trend()` helper to eliminate duplication between old and new commands.         
                                                                                                                                                      
## Changes                                                                                                                                            
                                                                                                                                                      
### CLI (`population_trend/cli.py`)                                                                                                                   
- Added `render-population-trend` command (same interface, same behavior).                                                                            
- Deprecated `plot-population-trend` with:                                                                                                            
  - Typer `deprecated=True` flag;                                                                                                                     
  - `typer.secho()` yellow warning to stderr at invocation;                                                                                           
  - `warnings.warn(DeprecationWarning)` for programmatic consumers.                                                                                   
- Both commands delegate to a single `_render_population_trend()` private function (DRY).                                                             
                                                                                                                                                      
### CI/CD (`.github/workflows/actions.yml`)                                                                                                           
- Added `feature/*` to push triggers. 
- Wrapped every deploy/publish step with `if: github.ref_name == 'develop'` so feature branches run tests/lint only.

### Changelog (`CHANGELOG.md`)
- Documented the new command under **Added**.
- Documented deprecation notice under **Deprecated** with the planned removal version (v6.0.0).

### Refactoring (`population_trend/population_growth_model.py`)
- Refactored `set_labels()` to use a dictionary structure, laying groundwork for future localization (extensibility without behavioral change).

### Tests (`tests/test_cli.py`, `tests/test_Population_trend.py`)
- Fixed variable ordering (`Plotter` moved after `Sparse_Plotter`).
- Updated test data path references (replaced `output_figure` with `data_path_for_trend`).
- Enhanced `test_app_plot_population_trend` to verify deprecation notice and new command name appear in help output.
- Added `test_render_population_trend_new_command_works` to validate the new command produces output correctly.

## Migration path

Users can safely replace `plot-population-trend` with `render-population-trend` in scripts. The old name continues to work but emits deprecation warnings. Removal is planned for v6.0.0.


